### PR TITLE
Change data structure in `Pop` from `Dict` to `Dictionary` from the Dictionaries.jl package

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -53,6 +53,12 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
+[[deps.Dictionaries]]
+deps = ["Indexing", "Random"]
+git-tree-sha1 = "63004a55faf43a5f7be7f5eca36ce355e9a75b2c"
+uuid = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
+version = "0.3.18"
+
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -66,6 +72,11 @@ version = "0.8.6"
 [[deps.Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.Indexing]]
+git-tree-sha1 = "ce1566720fd6b19ff3411404d4b977acd4814f9f"
+uuid = "313cdc1a-70c2-5d6a-ae34-0150d3930a38"
+version = "1.1.1"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["PierreBarrat <p.barrat@live.fr>"]
 version = "0.1.0"
 
 [deps]
+Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"

--- a/src/WrightFisher.jl
+++ b/src/WrightFisher.jl
@@ -1,5 +1,6 @@
 module WrightFisher
 
+using Dictionaries
 using LinearAlgebra
 using PoissonRandom
 using RandomNumbers

--- a/src/evolve.jl
+++ b/src/evolve.jl
@@ -17,7 +17,6 @@ function mutate!(pop::Pop, rng = Xorshifts.Xoroshiro128Plus())
 		C = Int(floor(pop.counts[id]))
 		z = 0
 		i = 1
-		# while i < C
 		for i in 1:C
 			nm = pois_rand(rng, λ)
 			if nm > 0
@@ -34,7 +33,7 @@ function mutate!(pop::Pop, rng = Xorshifts.Xoroshiro128Plus())
 end
 
 function select!(pop::Pop)
-	for (id, x) in pop.genotypes
+	for (id, x) in pairs(pop.genotypes)
 		pop.counts[id] *= 1+fitness(x, pop.fitness)
 	end
 
@@ -42,7 +41,7 @@ function select!(pop::Pop)
 end
 function select!(pop::Pop{ExpiringFitness})
 	sum_frequencies!(pop)
-	for (id, x) in pop.genotypes
+	for (id, x) in pairs(pop.genotypes)
 		pop.counts[id] *= 1+fitness(x, pop.fitness)
 	end
 
@@ -51,10 +50,10 @@ end
 
 
 function sample!(pop::Pop, rng = Xorshifts.Xoroshiro128Plus())
-	for (id, cnt) in pop.counts
+	for (id, cnt) in pairs(pop.counts)
 		pop.counts[id] = pois_rand(rng, cnt)
 	end
-	for (id,x) in pop.genotypes
+	for (id,x) in pairs(pop.genotypes)
 		if pop.counts[id] == 0.
 			delete!(pop, x)
 		end
@@ -65,11 +64,11 @@ end
 
 function normalize!(pop::Pop)
 	N = 0
-	for cnt in values(pop.counts)
+	for cnt in pop.counts
 		N += cnt
 	end
 	N /= pop.param.N
-	for (id, cnt) in pop.counts
+	for (id, cnt) in pairs(pop.counts)
 		pop.counts[id] = pop.counts[id] / N
 	end
 

--- a/src/objects.jl
+++ b/src/objects.jl
@@ -104,8 +104,8 @@ struct PopParam
 end
 
 mutable struct Pop{F<:FitnessLandscape}
-	genotypes::Dict{UInt, Genotype}
-	counts::Dict{UInt, Float64}
+	genotypes::Dictionary{UInt, Genotype}
+	counts::Dictionary{UInt, Float64}
 	N::Float64 # real pop size (can vary)
 	fitness::F
 	param::PopParam
@@ -169,15 +169,21 @@ end
 function ones_pop(fitness, param)
 	x = Genotype(param.L)
 	return Pop(
-		Dict(x.id => x), # genotypes
-		Dict(x.id => Float64(param.N)), # counts
+		Dictionary([x.id], [x]), # genotypes
+		Dictionary([x.id], [Float64(param.N)]), # counts
 		Float64(param.N),
 		fitness, # fitness landscape
 		param
 	)
 end
 function random_pop(fitness, param)
-	pop = Pop(Dict{UInt64, WrightFisher.Genotype}(), Dict{UInt64, Float64}(), Float64(param.N), fitness, param)
+	pop = Pop(
+		Dictionary{UInt64, WrightFisher.Genotype}(),
+		Dictionary{UInt64, Float64}(),
+		Float64(param.N),
+		fitness,
+		param
+	)
 	for n in 1:param.N
 		push!(pop, Genotype(rand([-1,1], param.L)))
 	end
@@ -191,8 +197,8 @@ function Base.push!(pop::Pop, x::Genotype, n=1.)
 	if in(x, pop)
 		pop.counts[x.id] += n
 	else
-		pop.genotypes[x.id] = x
-		pop.counts[x.id] = n
+		insert!(pop.genotypes, x.id, x)
+		insert!(pop.counts, x.id, n)
 	end
 	return pop
 end

--- a/src/pop_methods.jl
+++ b/src/pop_methods.jl
@@ -10,7 +10,7 @@ Single site frequencies of `pop`.
 """
 function frequencies(pop::Pop)
 	f1 = zeros(Float64, 2 * pop.param.L)
-	for (id, x) in pop.genotypes
+	for (id, x) in pairs(pop.genotypes)
 		# f1 .+= x.seq * pop.counts[id]
 		for (i,s) in enumerate(x.seq)
 			if s > 0
@@ -31,7 +31,7 @@ end
 f1(pop::Pop) = frequencies(pop)
 function f2(pop::Pop)
 	f2 = zeros(Float64, 2 * pop.param.L, 2 * pop.param.L)
-	for (id, x) in pop.genotypes
+	for (id, x) in pairs(pop.genotypes)
 		for i in 1:length(x.seq), j in i:length(x.seq)
 			if x.seq[i] > 0 && x.seq[j] > 0
 				f2[2*(i-1) + 1, 2*(j-1) + 1] += pop.counts[id]
@@ -62,7 +62,7 @@ Update `pop.fitness.integrated_freq`: for the state `s` at each position `i`,
 add the frequency of `s` to `integrated_freq` if `s` is favored by the field at `i`.
 """
 function sum_frequencies!(pop::Pop{ExpiringFitness})
-	for (id,x) in pop.genotypes
+	for (id,x) in pairs(pop.genotypes)
 		for (i,(s,h)) in enumerate(zip(x.seq, pop.fitness.H))
 			if h != 0 && sign(h) == sign(s)
 				pop.fitness.integrated_freq[i] += pop.counts[id]/pop.N


### PR DESCRIPTION
This solves a memory issue. The `Dict` type cannot be shrinked: 
```
d = Dict(i=>i for i in 1:1_000_000) # Large dict
for i in 2:1_000_000
    delete!(d, i)
end
# d will use the same amount of memory after this ... 
```
This makes simulations slower when initializing with a random set of genotypes.  